### PR TITLE
bacon: Skip redundant dtc build step

### DIFF
--- a/mkbootimg.mk
+++ b/mkbootimg.mk
@@ -19,13 +19,11 @@ G2_DTS_FILE = $(lastword $(subst /, ,$(1)))
 DTB_FILE = $(addprefix $(KERNEL_OUT)/arch/arm/boot/,$(patsubst %.dts,%.dtb,$(call G2_DTS_FILE,$(1))))
 ZIMG_FILE = $(addprefix $(KERNEL_OUT)/arch/arm/boot/,$(patsubst %.dts,%-zImage,$(call G2_DTS_FILE,$(1))))
 KERNEL_ZIMG = $(KERNEL_OUT)/arch/arm/boot/zImage
-DTC = $(KERNEL_OUT)/scripts/dtc/dtc
 
 define append-g2-dtb
 mkdir -p $(KERNEL_OUT)/arch/arm/boot;\
 $(foreach G2_DTS_NAME, $(G2_DTS_NAMES), \
    $(foreach d, $(G2_DTS_FILES), \
-      $(DTC) -p 1024 -O dtb -o $(call DTB_FILE,$(d)) $(d); \
       cat $(KERNEL_ZIMG) $(call DTB_FILE,$(d)) > $(call ZIMG_FILE,$(d));))
 endef
 


### PR DESCRIPTION
- Creating dtb is now done as a step of the inline kernel build.

Change-Id: I9f0689082f04999a45dfc2d62685dc342c781601
